### PR TITLE
KNVB api response changed

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -78,7 +78,7 @@ class Api
 	 */
 	public function map($json, $object)
 	{
-		return $this->mapper->map($json, $object);
+		return $this->mapper->map((object) $json, $object);
 	}
 
 
@@ -99,7 +99,7 @@ class Api
 		if (isset($response['List']) && isset($response['List'][0])) {
 
 			/** @var Club $club */
-			$this->club = $this->mapper->map($response['List'][0], new Club($this));
+			$this->club = $this->map($response['List'][0], new Club($this));
 			$this->client->authenticate($this->club->PHPSESSID, $this->key);
 
 			return $this->club;

--- a/src/Club.php
+++ b/src/Club.php
@@ -50,7 +50,7 @@ class Club extends AbstractItem
 
     /**
      * Twitter account voor club
-     * @var string
+     * @var array
      */
     public $twitter;
 
@@ -130,7 +130,7 @@ class Club extends AbstractItem
 
     /**
      * Met deze call kan een listing van wedstrijden van de hele club worden opgehaald.
-     * 
+     *
      * @param string|int $weeknummer
      * @param string $comptype
      * @param string $zaalveld


### PR DESCRIPTION
KNVB changed twitter property to an array and `JsonMapper` doesn't support arrays and it was changed in the response. Typecast the first level of array items to an object and it work again.
